### PR TITLE
model/tour

### DIFF
--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -22,21 +22,6 @@ interface SimpleTour {
   startDates: string[];
 }
 
-export const validateID = (
-  request: Request,
-  response: Response,
-  next: NextFunction,
-  val: number
-) => {
-  if (!val || val > tours.length || val < 0) {
-    return response.status(404).send({
-      status: ResponseStatus.FAILURE,
-      message: ErrorMessages.INVALID_ID,
-    });
-  }
-  next();
-};
-
 export const getAllTours = (request: Request, response: Response) => {};
 
 export const getTour = (request: Request, response: Response) => {};

--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 
-import { TourModel, Tour } from '../models/tourModel';
+import { TourModel } from '../models/tourModel';
 
 import { ResponseStatus } from '../utils/responseStatus';
 import { ErrorMessages } from '../utils/errorMessages';

--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import { Request, Response, NextFunction } from 'express';
 
 import { TourModel } from '../models/tourModel';
@@ -26,7 +25,22 @@ export const getAllTours = (request: Request, response: Response) => {};
 
 export const getTour = (request: Request, response: Response) => {};
 
-export const createTour = (request: Request, response: Response) => {};
+export const createTour = async (request: Request, response: Response) => {
+  try {
+    const tour = await TourModel.create(request.body);
+    response.status(201).json({
+      status: ResponseStatus.SUCCESS,
+      data: {
+        tour,
+      },
+    });
+  } catch (error) {
+    response.status(400).json({
+      status: ResponseStatus.FAILURE,
+      message: ErrorMessages.SERVER_OFFLINE,
+    });
+  }
+};
 
 export const updateTour = (request: Request, response: Response) => {};
 

--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -73,6 +73,29 @@ export const createTour = async (request: Request, response: Response) => {
   }
 };
 
-export const updateTour = (request: Request, response: Response) => {};
+export const updateTour = async (request: Request, response: Response) => {
+  try {
+    const tour = await TourModel.findByIdAndUpdate(
+      +request.params.id,
+      request.body,
+      {
+        new: true,
+        runValidators: true,
+      }
+    );
+
+    response.status(200).json({
+      status: ResponseStatus.SUCCESS,
+      data: {
+        tour,
+      },
+    });
+  } catch (error) {
+    response.status(400).json({
+      status: ResponseStatus.FAILURE,
+      message: ErrorMessages.SERVER_OFFLINE,
+    });
+  }
+};
 
 export const deleteTour = (request: Request, response: Response) => {};

--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -21,7 +21,23 @@ interface SimpleTour {
   startDates: string[];
 }
 
-export const getAllTours = (request: Request, response: Response) => {};
+export const getAllTours = async (request: Request, response: Response) => {
+  const tours = await TourModel.find();
+  try {
+    response.status(200).json({
+      status: ResponseStatus.SUCCESS,
+      results: tours.length,
+      data: {
+        tours,
+      },
+    });
+  } catch (error) {
+    response.status(500).json({
+      status: ResponseStatus.FAILURE,
+      message: ErrorMessages.SERVER_OFFLINE,
+    });
+  }
+};
 
 export const getTour = (request: Request, response: Response) => {};
 

--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -1,25 +1,9 @@
 import { Request, Response } from 'express';
 
-import { TourModel } from '../models/tourModel';
+import { TourModel, Tour } from '../models/tourModel';
 
 import { ResponseStatus } from '../utils/responseStatus';
 import { ErrorMessages } from '../utils/errorMessages';
-
-interface SimpleTour {
-  id: number;
-  name: string;
-  duration: number;
-  maxGroupSize: number;
-  difficulty: string;
-  ratingsAverage: number;
-  ratingsQuantity: number;
-  price: number;
-  summary: string;
-  description: string;
-  imageCover: string;
-  images: string[];
-  startDates: string[];
-}
 
 export const getAllTours = async (request: Request, response: Response) => {
   const tours = await TourModel.find();

--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -39,7 +39,22 @@ export const getAllTours = async (request: Request, response: Response) => {
   }
 };
 
-export const getTour = (request: Request, response: Response) => {};
+export const getTour = async (request: Request, response: Response) => {
+  try {
+    const tour = TourModel.findById(+request.params.id);
+    response.status(200).json({
+      status: ResponseStatus.SUCCESS,
+      data: {
+        tour,
+      },
+    });
+  } catch (error) {
+    response.status(404).json({
+      status: ResponseStatus.FAILURE,
+      message: ErrorMessages.TOUR_DOES_NOT_EXIST,
+    });
+  }
+};
 
 export const createTour = async (request: Request, response: Response) => {
   try {

--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from 'express';
+import { Request, Response } from 'express';
 
 import { TourModel } from '../models/tourModel';
 
@@ -41,7 +41,7 @@ export const getAllTours = async (request: Request, response: Response) => {
 
 export const getTour = async (request: Request, response: Response) => {
   try {
-    const tour = TourModel.findById(+request.params.id);
+    const tour = TourModel.findById(request.params.id);
     response.status(200).json({
       status: ResponseStatus.SUCCESS,
       data: {
@@ -76,7 +76,7 @@ export const createTour = async (request: Request, response: Response) => {
 export const updateTour = async (request: Request, response: Response) => {
   try {
     const tour = await TourModel.findByIdAndUpdate(
-      +request.params.id,
+      request.params.id,
       request.body,
       {
         new: true,
@@ -98,4 +98,20 @@ export const updateTour = async (request: Request, response: Response) => {
   }
 };
 
-export const deleteTour = (request: Request, response: Response) => {};
+export const deleteTour = async (request: Request, response: Response) => {
+  try {
+    const result = await TourModel.findByIdAndDelete(request.params.id);
+    if (result) {
+      response.status(204).json({
+        status: ResponseStatus.SUCCESS,
+      });
+    } else {
+      throw Error;
+    }
+  } catch (error) {
+    response.status(400).json({
+      status: ResponseStatus.FAILURE,
+      message: ErrorMessages.SERVER_OFFLINE,
+    });
+  }
+};

--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import { Request, Response, NextFunction } from 'express';
 
+import { TourModel } from '../models/tourModel';
+
 import { ResponseStatus } from '../utils/responseStatus';
 import { ErrorMessages } from '../utils/errorMessages';
 
@@ -20,10 +22,6 @@ interface SimpleTour {
   startDates: string[];
 }
 
-const tours: SimpleTour[] = JSON.parse(
-  fs.readFileSync(`${__dirname}/../dev-data/data/tours-simple.json`, 'utf-8')
-);
-
 export const validateID = (
   request: Request,
   response: Response,
@@ -39,91 +37,12 @@ export const validateID = (
   next();
 };
 
-export const getAllTours = (request: Request, response: Response) => {
-  if (!tours.length) {
-    response.status(500).json({
-      status: ResponseStatus.FAILURE,
-      message: ErrorMessages.SERVER_OFFLINE,
-    });
-  }
+export const getAllTours = (request: Request, response: Response) => {};
 
-  response.status(200).json({
-    status: ResponseStatus.SUCCESS,
-    results: tours.length,
-    data: {
-      tours,
-    },
-  });
-};
+export const getTour = (request: Request, response: Response) => {};
 
-export const getTour = (request: Request, response: Response) => {
-  const tour = tours.find((tour) => +request.params.id === tour.id);
+export const createTour = (request: Request, response: Response) => {};
 
-  if (!tour) {
-    response.status(404).json({
-      status: ResponseStatus.FAILURE,
-      message: ErrorMessages.TOUR_DOES_NOT_EXIST,
-    });
-  }
+export const updateTour = (request: Request, response: Response) => {};
 
-  response.status(200).json({
-    status: ResponseStatus.SUCCESS,
-    results: 1,
-    data: {
-      tour,
-    },
-  });
-};
-
-export const createTour = (request: Request, response: Response) => {
-  const newId = tours[tours.length - 1].id + 1;
-  const newTour = Object.assign({ id: newId }, request.body);
-  tours.push(newTour);
-  fs.writeFile(
-    `${__dirname}/dev-data/data/tours-simple.json`,
-    JSON.stringify(tours),
-    (err) => {
-      if (err) return console.log('File was not written!');
-      response.status(201).json({
-        status: ResponseStatus.SUCCESS,
-        data: {
-          tour: newTour,
-        },
-      });
-    }
-  );
-};
-
-export const updateTour = (request: Request, response: Response) => {
-  const tour = tours.find((tour) => +request.params.id === tour.id);
-
-  if (!tour) {
-    response.status(404).json({
-      status: ResponseStatus.FAILURE,
-      message: ErrorMessages.TOUR_DOES_NOT_EXIST,
-    });
-  }
-
-  response.status(200).send({
-    status: ResponseStatus.SUCCESS,
-    data: {
-      tour,
-    },
-  });
-};
-
-export const deleteTour = (request: Request, response: Response) => {
-  const tour = tours.find((tour) => +request.params.id === tour.id);
-
-  if (!tour) {
-    response.status(404).json({
-      status: ResponseStatus.FAILURE,
-      message: ErrorMessages.TOUR_DOES_NOT_EXIST,
-    });
-  }
-
-  response.status(204).send({
-    status: ResponseStatus.SUCCESS,
-    data: null,
-  });
-};
+export const deleteTour = (request: Request, response: Response) => {};

--- a/models/tourModel.ts
+++ b/models/tourModel.ts
@@ -1,6 +1,6 @@
-import { Schema, model } from 'mongoose';
+import { Schema, model, Document } from 'mongoose';
 
-interface Tour {
+interface Tour extends Document {
   name: string;
   rating?: number;
   price: number;

--- a/models/tourModel.ts
+++ b/models/tourModel.ts
@@ -1,0 +1,25 @@
+import { Schema, model } from 'mongoose';
+
+interface Tour {
+  name: string;
+  rating?: number;
+  price: number;
+}
+
+const tourSchema = new Schema<Tour>({
+  name: {
+    type: String,
+    required: [true, 'A tour must have a name'],
+    unique: true,
+  },
+  rating: {
+    type: Number,
+    default: 4.5,
+  },
+  price: {
+    type: Number,
+    required: [true, 'A tour must have a price'],
+  },
+});
+
+export const TourModel = model<Tour>('Tour', tourSchema);

--- a/models/tourModel.ts
+++ b/models/tourModel.ts
@@ -1,9 +1,20 @@
 import { Schema, model, Document } from 'mongoose';
 
-interface Tour extends Document {
+export interface Tour extends Document {
   name: string;
-  rating?: number;
+  duration: number;
+  maxGroupSize: number;
+  difficulty: string;
+  ratingsAverage?: number;
+  ratingsQuantity?: number;
   price: number;
+  priceDiscount?: number;
+  summary: string;
+  description?: string;
+  imageCover: string;
+  images?: string[];
+  createdAt: Date;
+  startDates: Date[];
 }
 
 const tourSchema = new Schema<Tour>({
@@ -11,15 +22,53 @@ const tourSchema = new Schema<Tour>({
     type: String,
     required: [true, 'A tour must have a name'],
     unique: true,
+    trim: true,
   },
-  rating: {
+  duration: {
+    type: Number,
+    required: [true, 'A tour must have a duration'],
+  },
+  maxGroupSize: {
+    type: Number,
+    required: [true, 'A tour must have a group size'],
+  },
+  difficulty: {
+    type: String,
+    required: [true, 'A tour must have a difficulty'],
+  },
+  ratingsAverage: {
     type: Number,
     default: 4.5,
+  },
+  ratingsQuantity: {
+    type: Number,
+    default: 0,
   },
   price: {
     type: Number,
     required: [true, 'A tour must have a price'],
   },
+  priceDiscount: Number,
+  summary: {
+    type: String,
+    trim: true,
+    required: [true, 'A tour must have a description'],
+  },
+  description: {
+    type: String,
+    trim: true,
+  },
+  imageCover: {
+    type: String,
+    trim: true,
+    required: [true, 'A tour must have a cover image'],
+  },
+  images: [String],
+  createdAt: {
+    type: Date,
+    default: Date.now(),
+  },
+  startDates: [Date],
 });
 
 export const TourModel = model<Tour>('Tour', tourSchema);

--- a/models/tourModel.ts
+++ b/models/tourModel.ts
@@ -1,6 +1,6 @@
 import { Schema, model, Document } from 'mongoose';
 
-export interface Tour extends Document {
+interface Tour extends Document {
   name: string;
   duration: number;
   maxGroupSize: number;

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   "dependencies": {
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "mongoose": "^6.0.12"
+    "mongoose": "^5.10.19"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
+    "@types/mongoose": "^5.10.5",
     "@types/node": "^16.11.6",
     "nodemon": "^2.0.14",
     "typescript": "^4.4.4"

--- a/routes/tourRoutes.ts
+++ b/routes/tourRoutes.ts
@@ -5,11 +5,9 @@ import {
   getTour,
   updateTour,
   deleteTour,
-  validateID,
 } from '../controllers/tourController';
 
 const router = express.Router();
-router.param('id', validateID);
 router.route('/').get(getAllTours).post(createTour);
 router.route('/:id').get(getTour).patch(updateTour).delete(deleteTour);
 export default router;

--- a/server.ts
+++ b/server.ts
@@ -9,7 +9,14 @@ const dbConn: string | undefined = process.env.DATABASE?.replace(
 );
 
 if (dbConn) {
-  mongoose.connect(dbConn).then(() => console.log('DB connection successful'));
+  mongoose
+    .connect(dbConn, {
+      useNewUrlParser: true,
+      useCreateIndex: true,
+      useFindAndModify: false,
+      useUnifiedTopology: true,
+    })
+    .then(() => console.log('DB connection successful'));
 }
 
 const port = process.env.PORT || 3000;


### PR DESCRIPTION
# What’s this PR do?

- Downgrades mongoose version that was installed from v6 to v5.10.5 and get types for mongoose from 3rd party source.
- Create tourModel that defines the interface Tour, model, and the Tour Schema for MongoDB.
- Expands the data required to create a Tour to an almost full data set. Additional properties depend on other data sources (such as a user) and will be implemented later.
- Refactors tourController to remove all local json data references and uses the Atlas MongoDB.
- Reconfigure the mongoose db connection and Tour interface to work with v5.10.5 instead of v6.
- Implements all CRUD functionality for a Tour.
- Implements some error handling for Tour Controller.

# Where should the reviewer start?

- Pull this branch.
- Run `npm i`.
- Have DB configurations ready for Atlas and mongoose in .env file.

# How should this be manually tested?

- Using Postman, perform all CRUD all operations relating to a Tour.
- Test error messages as well as successful CRUD operations.

# Any background context you want to provide?

- Error messages and validation will be done during a later branch. It will be configured to use specific middleware to know which error messages to return based on MongoDB errors instead of the current generic ones.
- The reason for downgrading mongoose back to a stable version of v5.10.5 was strictly because of Typescript and the VSCode editor. In the next minor update of mongoose (v5.11 and greater), they implemented their own type files. While their type files are much more accurate than the 3rd party version, it also has a significant performance impact on VSCode. This does not apply to only type checking with using mongoose, it slows all actions and functions of VSCode. To the point that it takes anywhere from 3 - 12 seconds before the changes register and it updates the editor. This was causing much more strain than using the most recent version of mongoose.

# What are the relevant tickets?

n/a

# Screenshots (if appropriate)

n/a

# Questions:

n/a

