### PR TITLE
feature/advTourFiltering

### DIFF
--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -20,6 +20,16 @@ export const getAllTours = async (request: Request, response: Response) => {
     );
 
     let query = TourModel.find(JSON.parse(queryString));
+
+    //* Sorting
+    if (request.query.sort) {
+      const convertQueryToString = request.query.sort as string;
+      const sortBy = convertQueryToString.split(',').join(' ');
+      query = query.sort(sortBy);
+    } else {
+      query = query.sort('-createdAt');
+    }
+
     const tours = await query;
     response.status(200).json({
       status: ResponseStatus.SUCCESS,

--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -12,7 +12,14 @@ export const getAllTours = async (request: Request, response: Response) => {
     const excludedFields = ['page', 'sort', 'limit', 'fields'];
     excludedFields.forEach((el) => delete queryObj[el]);
 
-    let query = TourModel.find(queryObj);
+    //* Advanced Filtering
+    let queryString = JSON.stringify(queryObj);
+    queryString = queryString.replace(
+      /\b(gte|gt|lte|lt)\b/g,
+      (match) => `$${match}`
+    );
+
+    let query = TourModel.find(JSON.parse(queryString));
     const tours = await query;
     response.status(200).json({
       status: ResponseStatus.SUCCESS,

--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -5,6 +5,10 @@ import { TourModel } from '../models/tourModel';
 import { ResponseStatus } from '../utils/responseStatus';
 import { ErrorMessages } from '../utils/errorMessages';
 
+const formatStringForQuery = (queryString: string): string => {
+  return queryString.split(',').join(' ');
+};
+
 export const getAllTours = async (request: Request, response: Response) => {
   try {
     //* Filtering query string
@@ -23,11 +27,19 @@ export const getAllTours = async (request: Request, response: Response) => {
 
     //* Sorting
     if (request.query.sort) {
-      const convertQueryToString = request.query.sort as string;
-      const sortBy = convertQueryToString.split(',').join(' ');
+      const queryAsString = request.query.sort as string;
+      const sortBy = formatStringForQuery(queryAsString);
       query = query.sort(sortBy);
     } else {
       query = query.sort('-createdAt');
+    }
+
+    if (request.query.fields) {
+      const fields = request.query.fields as string;
+      const parseString = formatStringForQuery(fields);
+      query = query.select(parseString);
+    } else {
+      query = query.select('-__v');
     }
 
     const tours = await query;

--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -6,8 +6,14 @@ import { ResponseStatus } from '../utils/responseStatus';
 import { ErrorMessages } from '../utils/errorMessages';
 
 export const getAllTours = async (request: Request, response: Response) => {
-  const tours = await TourModel.find();
   try {
+    //* Filtering query string
+    const queryObj = { ...request.query };
+    const excludedFields = ['page', 'sort', 'limit', 'fields'];
+    excludedFields.forEach((el) => delete queryObj[el]);
+
+    let query = TourModel.find(queryObj);
+    const tours = await query;
     response.status(200).json({
       status: ResponseStatus.SUCCESS,
       results: tours.length,

--- a/models/tourModel.ts
+++ b/models/tourModel.ts
@@ -1,6 +1,6 @@
-import { Schema, model, Document } from 'mongoose';
+import { Schema, model } from 'mongoose';
 
-interface Tour extends Document {
+interface Tour {
   name: string;
   duration: number;
   maxGroupSize: number;
@@ -66,7 +66,7 @@ const tourSchema = new Schema<Tour>({
   images: [String],
   createdAt: {
     type: Date,
-    default: Date.now(),
+    default: new Date(Date.now()),
   },
   startDates: [Date],
 });

--- a/models/tourModel.ts
+++ b/models/tourModel.ts
@@ -67,6 +67,7 @@ const tourSchema = new Schema<Tour>({
   createdAt: {
     type: Date,
     default: new Date(Date.now()),
+    select: false,
   },
   startDates: [Date],
 });

--- a/package.json
+++ b/package.json
@@ -19,11 +19,10 @@
   "dependencies": {
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "mongoose": "^5.10.19"
+    "mongoose": "^6.0.12"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "@types/mongoose": "^5.10.5",
     "@types/node": "^16.11.6",
     "nodemon": "^2.0.14",
     "ts-node": "^10.4.0",

--- a/server.ts
+++ b/server.ts
@@ -9,14 +9,7 @@ const dbConn: string | undefined = process.env.DATABASE?.replace(
 );
 
 if (dbConn) {
-  mongoose
-    .connect(dbConn, {
-      useNewUrlParser: true,
-      useCreateIndex: true,
-      useFindAndModify: false,
-      useUnifiedTopology: true,
-    })
-    .then(() => console.log('DB connection successful'));
+  mongoose.connect(dbConn).then(() => console.log('DB connection successful'));
 }
 
 const port = process.env.PORT || 3000;


### PR DESCRIPTION
# What’s this PR do?

- This PR implements query string parameters when querying for all Tours.
- Filtering happens first, in order to clean the querying url for specifications that mongoose and mongodb do not match or need additional information first.
- Adds the `$` when a query for `gte, gt, lte, lt` is submitted.
- Builds a query object to chain on multiple specifications for a request.
- By default, sorts all the trips by when they were created to see new Tours first.
- A sort parameter can be specified during submission.
- A fields parameter can be specified to limit the data that is returned, rather than the entire Tour data set.
- By default, strips the `__v` that is added in by MongoDB.
- Automatically implements a limit of 100, to ensure that large data sets are not returned and slows the API.
- Pagination to specify a specific page and limit for how many Tours are returned.
- A light amount of error handling. This will be handled more in-depth at a later time.
- Updates Mongoose back to v6, as v5.10.19 and 3rd party types were causing the same issue with VSCode.

# Where should the reviewer start?

- Pull this branch.
- Start the server with `npm start`.

# How should this be manually tested?

- Use Postman to pass in parameters in a query string.
- A common url with query parameters can look like this `localhost:3000/api/v1/tours?sort=-price,-ratingsAverage&page=1&limit=3&fields=name,startDate,duration,difficulty,price,summary`.
- Sort can be specified with a common separating each additional parameter you want to sort by. Adding a `-` in the front will be descending order, no `-` will be ascending order.
- Page and Limit are their own properties.
- Fields can be structured like sort, no `-` are accepted here.
- Try playing with multiple different queries and ensure data returned matches.

# Any background context you want to provide?

- If you ran the script to upload all of your data at once. If you try to search with the default `-createdAt` to return trips first, it can break the pagination. This is a confirmed issue with something that MongoDB is doing on the data return, as it was an issue I had with Compass as well as Postman. Sometimes, it will duplicate entries when going through pages. The easy fix for his is modify the `createdAt` property so they are not all the same. If a client attempts to import multiple trips at once, this will be adjusted in a bug branch to ensure the same thing does not happen.

# What are the relevant tickets?

n/a

# Screenshots (if appropriate)

n/a

# Questions:

n/a

