### PR TITLE
feature/urlSlugs

### DIFF
--- a/controllers/tourController.ts
+++ b/controllers/tourController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 
 import { TourModel, Tour } from '../models/tourModel';
-import { APIFeatures } from '../utils/ApiFeatures';
+import { APIFeatures } from '../utils/APIFeatures';
 
 import { ResponseStatus } from '../utils/responseStatus';
 import { ErrorMessages } from '../utils/errorMessages';

--- a/models/tourModel.ts
+++ b/models/tourModel.ts
@@ -1,4 +1,5 @@
 import { Schema, model } from 'mongoose';
+import slugify from 'slugify';
 
 export interface Tour {
   name: string;
@@ -15,6 +16,7 @@ export interface Tour {
   images?: string[];
   createdAt: Date;
   startDates: Date[];
+  slug: string;
 }
 
 const tourSchema = new Schema<Tour>({
@@ -70,6 +72,12 @@ const tourSchema = new Schema<Tour>({
     select: false,
   },
   startDates: [Date],
+  slug: String,
+});
+
+tourSchema.pre('save', function (next: Function) {
+  this.slug = slugify(this.name, { lower: true });
+  next();
 });
 
 export const TourModel = model<Tour>('Tour', tourSchema);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "mongoose": "^6.0.12"
+    "mongoose": "^6.0.12",
+    "slugify": "^1.6.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",


### PR DESCRIPTION
# What’s this PR do?

- This PR adds a `pre middleware` that will add a slug property into the Schema for a Tour.
- Installs slugify to generate slugs.
- Fixes bug with improper file name during file rename.

# Where should the reviewer start?

- Pull this branch.
- Start server with `npm start`.

# How should this be manually tested?

- Save a new Tour document and ensure that the slug property is generated from the name of the Tour provided.

# Any background context you want to provide?

n/a

# What are the relevant tickets?

n/a

# Screenshots (if appropriate)

n/a

# Questions:

n/a

