### PR TITLE
feature/authController

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -3,11 +3,13 @@ import express, { Request, Response, NextFunction } from 'express';
 import { globalErrorHandler } from './controllers/errorController';
 import { AppErrorHandler } from './utils/AppErrorHandler';
 import tourRouter from './routes/tourRoutes';
+import userRouter from './routes/userRoutes';
 
 export const app = express();
 app.use(express.json());
 
 app.use('/api/v1/tours', tourRouter);
+app.use('/api/v1/users', userRouter);
 app.use('*', (req: Request, res: Response, next: NextFunction) => {
   next(
     AppErrorHandler.invokeError(

--- a/controllers/authController.ts
+++ b/controllers/authController.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express';
+import { UserModel, User } from '../models/userModel';
+import { asyncTryCatch } from '../utils/asyncTryCatch';
+import { ResponseStatus } from '../utils/responseStatus';
+
+export const signup = asyncTryCatch(
+  async (request: Request<User>, response: Response, next: NextFunction) => {
+    const newUser = await UserModel.create(request.body);
+
+    response.status(201).json({
+      status: ResponseStatus.SUCCESS,
+      data: {
+        user: newUser,
+      },
+    });
+  }
+);

--- a/models/userModel.ts
+++ b/models/userModel.ts
@@ -1,3 +1,4 @@
+import bcrypt from 'bcryptjs';
 import { Schema, model } from 'mongoose';
 import validator from 'validator';
 
@@ -44,6 +45,14 @@ const userSchema = new Schema<User>({
       message: 'The password and passwordConfirm fields must be the same',
     },
   },
+});
+
+userSchema.pre('save', async function (next: Function) {
+  if (!this.isModified('password')) return next();
+
+  this.password = await bcrypt.hash(this.password, 12);
+  this.passwordConfirm = undefined;
+  next();
 });
 
 export const UserModel = model<User>('User', userSchema);

--- a/models/userModel.ts
+++ b/models/userModel.ts
@@ -6,7 +6,7 @@ export interface User {
   email: string;
   photo?: string;
   password: string;
-  passwordConfirm?: string;
+  passwordConfirm: string;
 }
 
 const userSchema = new Schema<User>({
@@ -37,6 +37,12 @@ const userSchema = new Schema<User>({
     type: String,
     required: [true, 'A user must verify their passwords match'],
     trim: true,
+    validate: {
+      validator: function (this: { password: string }, value: string): boolean {
+        return this.password === value;
+      },
+      message: 'The password and passwordConfirm fields must be the same',
+    },
   },
 });
 

--- a/models/userModel.ts
+++ b/models/userModel.ts
@@ -31,7 +31,7 @@ const userSchema = new Schema<User>({
     type: String,
     required: [true, 'A user must have a valid password'],
     trim: true,
-    minlength: 8,
+    minlength: [8, 'A password must have a minimum of 8 characters'],
   },
   passwordConfirm: {
     type: String,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "homepage": "https://github.com/npdarrington/natours-api#readme",
   "dependencies": {
+    "@types/bcryptjs": "^2.4.2",
+    "bcryptjs": "^2.4.3",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "mongoose": "^6.0.12",

--- a/routes/userRoutes.ts
+++ b/routes/userRoutes.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { signup } from '../controllers/authController';
+
+const router = express.Router();
+
+router.post('/signup', signup);
+
+export default router;


### PR DESCRIPTION
- Initial authController
- Warn user if password is too short
- Create signup authController method
- Initial userRoutes
- Create signup post route and include in app
- Require passwordConfirm and validate matches password
- Install bcrypt and bcrypt types
- Hash password, prevent passwordConfirm fields from saving to db

# What’s this PR do?

- Creates authController with a signup method.
- Saves a new user to the DB.
- Encrypts password with bcrypt.
- Implements additional validation on userSchema.
- Creates userRoutes and implements into app.

# Where should the reviewer start?

- Pull this branch.
- Run `npm i`.
- Start server with `npm start` or `npm start:prod`.

# How should this be manually tested?

- Use Postman to post to this url `127.0.0.1:3000/api/v1/users/signup`.
- Create a body that satisfies all valid information - ensure successful save to DB.
- Verify password in encrypted on save and passwordConfirm field does not show in DB.
- Create a body that does not satisfy requirements. Test multiple error validators.

# Any background context you want to provide?

n/a

# What are the relevant tickets?

n/a

# Screenshots (if appropriate)

n/a

# Questions:

n/a

